### PR TITLE
Make setup.py work with Python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ import subprocess
 class PostInstallCommand(install):
     """Post-installation for installation mode."""
     def run(self):
-        print "inside install"
-        print "*******"
-        print "*******"
-        print "*******"
+        print("inside install")
+        print("*******")
+        print("*******")
+        print("*******")
         subprocess.check_call(['./package_build_scripts/build_library_package'])
         install.run(self)
 


### PR DESCRIPTION
Currently it won't work because of the brackets causing the program to exit
